### PR TITLE
feat: Adds eslint plugin for react hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     }
   },
 
-  plugins: ['babel', 'react'],
+  plugins: ['babel', 'react', 'react-hooks'],
 
   rules: {
     /* annoying to have to escape  */
@@ -40,6 +40,7 @@ module.exports = {
     'react/jsx-handler-names': ['error'],
     'react/jsx-first-prop-new-line': ['error', 'multiline'],
     'react/jsx-equals-spacing': ['error', 'never'],
-    'react/jsx-curly-spacing': [2, 'never']
+    'react/jsx-curly-spacing': [2, 'never'],
+    'react-hooks/rules-of-hooks': 'error'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1962,6 +1962,12 @@
         "prop-types": "^15.6.2"
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.0.2.tgz",
+      "integrity": "sha512-pY1RSD3CGkGOV+e+rzjfs+JXKRum7VlJKPHznhU0GnFWfDm6zKLmOmg/lKcwNRH3LTSnF2PbfF8x3w90tyHlYw==",
+      "dev": true
+    },
     "eslint-rule-composer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/nearmap/eslint-config-react#readme",
   "peerDependencies": {
     "eslint": ">= 5",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-hooks": "^1.0.2"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
@@ -32,6 +33,7 @@
     "eslint": "^5.5.0",
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-hooks": "^1.0.2",
     "npx-run": "^2.1.2",
     "semantic-release": "^15.9.12"
   },


### PR DESCRIPTION
add eslint plugin for react hooks

BREAKING CHANGE: Requires eslint-plugin-react-hooks to be installed in downstream modules